### PR TITLE
Fixed brew installation URL

### DIFF
--- a/rails-install-osx-rvm.sh
+++ b/rails-install-osx-rvm.sh
@@ -2,10 +2,13 @@ set -e
 
 echo "Installs Homebrew for installing other software"
 /usr/bin/ruby -e "$(/usr/bin/curl -fsSkL raw.github.com/mxcl/homebrew/go)"
-brew update
 
 echo "Installs Git"
 brew install git
+
+echo "Updates Homebrew"
+brew update
+
 
 echo "Installs RVM (Ruby Version Manager) for handling Ruby installation"
 curl -kL get.rvm.io | bash -s stable


### PR DESCRIPTION
Current URL responds with 404, updated it to current working URL from brew website (http://mxcl.github.com/homebrew/)
