### PR TITLE
warn about allowing a login shell in the terminal emulator

### DIFF
--- a/rails-install-ubuntu.sh
+++ b/rails-install-ubuntu.sh
@@ -46,4 +46,14 @@ echo "If the versions match, everything is installed correctly. If the versions
 don't match or errors are shown, something went wrong with the automated process 
 and we will help you do the installation the manual way at the event.
 
-Congrats!"
+Congrats!
+                                                                                 
+Make sure that all works well by running the application generator command:         
+    $ rails new railsgirls                                                       
+                                                                                 
+If you encounter the message:                                                    
+    The program 'rails' is currently not installed.                              
+                                                                                 
+It is just a hiccup with the shell, solutions:                                   
+    $ source ~/.rvm/scripts/rvm                                                  
+    Allow login shell, example http://rvm.io/integration/gnome-terminal/"


### PR DESCRIPTION
RVM does not work properly if it is run from terminal emulator that does not allow a login shell. The behaviour is easy to see by just trying to run: 
    $ rvm use

The scenario is well handled by RVM and instructions are given to the user. However, the rails install script encapsulates RVM and will never face a situation like this because, in line 16, the rvm script is being sourced.

The shell used for installation will display correctly the version numbers for Ruby and Rails, but once it exits the configuration will be lost.

I saw this behaviour in gnome-terminal, xterm and uxterm.
