### PR TITLE
Update ruby version, rvm in ubuntu installer

### DIFF
--- a/rails-install-ubuntu.sh
+++ b/rails-install-ubuntu.sh
@@ -12,12 +12,13 @@ echo "Installs ImageMagick for image processing"
 sudo apt-get install imagemagick --fix-missing -y
 
 echo "Installs RVM (Ruby Version Manager) for handling Ruby installation"
-curl -L get.rvm.io | bash -s stable
+gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+curl -sSL https://get.rvm.io | bash -s -- --version 1.26.11
 source ~/.rvm/scripts/rvm
 
 echo "Installs Ruby"
-rvm install 1.9.3-p547
-rvm use 1.9.3-p547 --default
+rvm install 2.2.1
+rvm use 2.2.1 --default
 
 gem install bundler --no-rdoc --no-ri
 gem install rails --no-rdoc --no-ri
@@ -29,13 +30,13 @@ echo -e "Now we are going to print some information to check that everything is 
 # echo -n "Should be brew 0.8 or higher:       brew "
 # brew -v
 
-echo -n "Should be sqlite 3.7.3 or higher: sqlite "
+echo -n "Should be sqlite 3.8.1 or higher: sqlite "
 sqlite3 --version
-echo -n "Should be rvm 1.6.32 or higher:          "
+echo -n "Should be rvm 1.26.11:          "
 rvm --version | sed '/^.*$/N;s/\n//g' | cut -c 1-10
-echo -n "Should be ruby 1.9.3-p547:                "
+echo -n "Should be ruby 2.2.1:                "
 ruby -v | cut -d " " -f 2
-echo -n "Should be Rails 3.2.2 or higher:         "
+echo -n "Should be Rails 4.2.1 or higher:         "
 rails -v
 echo -e "\n- - - - - -\n"
 


### PR DESCRIPTION
This updates the ruby version from 1.9.3 to 2.2.1 and installs public key for rvm in the Ubuntu installer. 

As of v1.26.0, rvm signs and verifies all releases, which requires downloading the public key for each release (see https://rvm.io/rvm/security for more details). 

- update: ruby version from 1.9.3 to 2.2.1
- update: rvm version from unspecified to 1.26.11
- add: install mpapis public key for rvm > 1.26.0 (see: https://rvm.io/rvm/security)
- update: expected version confirmation text

Closes #23