### PR TITLE
Remove libreadline from ubuntu installation script

### DIFF
--- a/rails-install-ubuntu.sh
+++ b/rails-install-ubuntu.sh
@@ -9,7 +9,7 @@ echo "Updates packages. Asks for your password."
 sudo apt-get update -y
 
 echo "Installs packages. Give your password when asked."
-sudo apt-get --ignore-missing install build-essential git-core curl openssl libssl-dev libcurl4-openssl-dev zlib1g zlib1g-dev libreadline libreadline-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev libsqlite3-0 sqlite3 libxml2-dev libxslt1-dev python-software-properties libffi-dev libgdm-dev libncurses5-dev automake autoconf libtool bison postgresql postgresql-contrib libpq-dev pgadmin3 libc6-dev nodejs -y
+sudo apt-get --ignore-missing install build-essential git-core curl openssl libssl-dev libcurl4-openssl-dev zlib1g zlib1g-dev libreadline-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev libsqlite3-0 sqlite3 libxml2-dev libxslt1-dev python-software-properties libffi-dev libgdm-dev libncurses5-dev automake autoconf libtool bison postgresql postgresql-contrib libpq-dev pgadmin3 libc6-dev nodejs -y
 
 echo "Installs ImageMagick for image processing"
 sudo apt-get install imagemagick --fix-missing -y


### PR DESCRIPTION
There's not `libreadline` package in Ubuntu (I checked in trusty and vivid). This provokes an error, canceling the installation.

http://packages.ubuntu.com/search?suite=trusty&searchon=names&keywords=libreadline