### PR TITLE
Update rails-install-ubuntu.sh to accommodate Ubuntu 15.04.

### DIFF
--- a/rails-install-ubuntu.sh
+++ b/rails-install-ubuntu.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "Adding PPA for up-to-date Node.js runtime. Give your password when asked."
-curl -sL https://deb.nodesource.com/setup_dev | sudo bash -
+wget -O - https://deb.nodesource.com/setup_dev | sudo bash -
 
 echo "Updates packages. Asks for your password."
 sudo apt-get update -y

--- a/rails-install-ubuntu.sh
+++ b/rails-install-ubuntu.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "Adding PPA for up-to-date Node.js runtime. Give your password when asked."
-sudo add-apt-repository ppa:chris-lea/node.js
+curl -sL https://deb.nodesource.com/setup_dev | sudo bash -
 
 echo "Updates packages. Asks for your password."
 sudo apt-get update -y


### PR DESCRIPTION
This commit allows users of 15.04+ and above to continue to use the script. Chris Lea's PPA does not have any references to 15.04+.

It is now recommended that to use NodeSource's own PPA to install nodejs. They have generously provided their own script to add their PPA to a user's system. I made reference to setup_dev, because it installs the semi-latest version (>.12), while their normal script installs stable (.10). 