### PR TITLE
Use distro node.js for new Xenial Ubuntu release. Fixes #35.

### DIFF
--- a/rails-install-ubuntu.sh
+++ b/rails-install-ubuntu.sh
@@ -2,8 +2,14 @@
 
 set -e
 
-echo "Adding PPA for up-to-date Node.js runtime. Give your password when asked."
-sudo add-apt-repository ppa:chris-lea/node.js
+if ! greq -q xenial /etc/lsb-release
+then
+  echo "Adding PPA for up-to-date Node.js runtime. Give your password when asked."
+  sudo add-apt-repository ppa:chris-lea/node.js
+else
+  : # Xenial not (yet, as of April 2016) supported by that ppa,
+    # use default distro node.js.
+fi
 
 echo "Updates packages. Asks for your password."
 sudo apt-get update -y


### PR DESCRIPTION
I assume that on Xenial, the default distro nodejs package (currently 4.2.6~dfsg-1ubuntu4) will be up-to-date enough for Rails'Girls purposes.