### PR TITLE
Do not allow running ubuntu script as root

### DIFF
--- a/rails-install-ubuntu.sh
+++ b/rails-install-ubuntu.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+if
+  [[ "${USER:-}" == "root" ]]
+then
+  echo "This script works only with normal user, it wont work with root, please log in as normal user and try again." >&2
+  exit 1
+fi
+
 set -e
 
 curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -


### PR DESCRIPTION
The script assumes user installation of RVM - and it's what I do recommend, added a check for root to prevent problems when it's run as `root`.