### PR TITLE
Get the rvm GPG key via curl from the rvm web side instead of via hkp.

### DIFF
--- a/rails-install-archlinux.sh
+++ b/rails-install-archlinux.sh
@@ -13,7 +13,8 @@ echo "Installs ImageMagick for image processing"
 sudo pacman -S --noconfirm imagemagick 
 
 echo "Installs RVM (Ruby Version Manager) for handling Ruby installation"
-gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+# Retrieve the GPG key.
+curl -sSL https://rvm.io/mpapis.asc | gpg --import -
 curl -sSL https://get.rvm.io | bash -s stable
 source ~/.rvm/scripts/rvm
 

--- a/rails-install-ubuntu.sh
+++ b/rails-install-ubuntu.sh
@@ -21,7 +21,8 @@ echo "Installs ImageMagick for image processing"
 sudo apt-get install imagemagick --fix-missing -y
 
 echo "Installs RVM (Ruby Version Manager) for handling Ruby installation"
-gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+# Retrieve the GPG key.
+curl -sSL https://rvm.io/mpapis.asc | gpg --import -
 curl -sSL https://get.rvm.io | bash -s stable
 source ~/.rvm/scripts/rvm
 


### PR DESCRIPTION
Rationale: hkp is less reliable if installation is behind a firewall,
and the installer might still work even if RVM changes its key.

FWIW: The previous code no longer works, as gpg nowadays requires a
"0x" prefix in front of the fingerprint.