### PR TITLE
Fix some error for Ubuntu18.04

### DIFF
--- a/rails-install-ubuntu.sh
+++ b/rails-install-ubuntu.sh
@@ -15,7 +15,7 @@ echo "Updates packages. Asks for your password."
 sudo apt-get update -y
 
 echo "Installs packages. Give your password when asked."
-sudo apt-get --ignore-missing install build-essential git-core curl openssl libssl-dev libcurl4-openssl-dev zlib1g zlib1g-dev libreadline-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev libsqlite3-0 sqlite3 libxml2-dev libxslt1-dev python-software-properties libffi-dev libgdm-dev libncurses5-dev automake autoconf libtool bison postgresql postgresql-contrib libpq-dev pgadmin3 libc6-dev nodejs -y
+sudo apt-get --ignore-missing install build-essential git-core curl openssl libssl-dev libcurl4-openssl-dev zlib1g zlib1g-dev libreadline6-dev libyaml-dev libsqlite3-dev libsqlite3-0 sqlite3 libxml2-dev libxslt1-dev libffi-dev software-properties-common libgdm-dev libncurses5-dev automake autoconf libtool bison postgresql postgresql-contrib libpq-dev pgadmin3 libc6-dev nodejs -y
 
 echo "Installs ImageMagick for image processing"
 sudo apt-get install imagemagick --fix-missing -y


### PR DESCRIPTION
The current script does not work with Ubuntu 18.04. This is because the 'libreadline6' and 'python-software-properties' that are installed in existing scripts are not available for installation (in Ubuntu version 18.04). So I solved this problem and sent a Pull Request.
```
Note, selecting 'libreadline-dev' instead of 'libreadline6-dev'
Package python-software-properties is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  software-properties-common

Package libreadline6 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'libreadline6' has no installation candidate
E: Package 'python-software-properties' has no installation candidate
```