### PR TITLE
Install node via snap

### DIFF
--- a/rails-install-ubuntu.sh
+++ b/rails-install-ubuntu.sh
@@ -12,12 +12,12 @@ set -e
 echo "Updates packages. Asks for your password."
 sudo apt-get update -y
 
-echo "Installs Node 6"
+echo "Installs Node 10"
 sudo apt-get install -y snapd
-sudo snap install node --classic --channel=6
+sudo snap install node --classic --channel=10
 
 echo "Installs packages. Give your password when asked."
-sudo apt-get --ignore-missing install build-essential git-core curl openssl libssl-dev libcurl4-openssl-dev zlib1g zlib1g-dev libreadline6-dev libyaml-dev libsqlite3-dev libsqlite3-0 sqlite3 libxml2-dev libxslt1-dev libffi-dev software-properties-common libgdm-dev libncurses5-dev automake autoconf libtool bison postgresql postgresql-contrib libpq-dev pgadmin3 libc6-dev nodejs -y
+sudo apt-get --ignore-missing install build-essential git-core curl openssl libssl-dev libcurl4-openssl-dev zlib1g zlib1g-dev libreadline6-dev libyaml-dev libsqlite3-dev libsqlite3-0 sqlite3 libxml2-dev libxslt1-dev libffi-dev software-properties-common libgdm-dev libncurses5-dev automake autoconf libtool bison postgresql postgresql-contrib libpq-dev pgadmin3 libc6-dev -y
 
 echo "Installs ImageMagick for image processing"
 sudo apt-get install imagemagick --fix-missing -y

--- a/rails-install-ubuntu.sh
+++ b/rails-install-ubuntu.sh
@@ -9,10 +9,12 @@ fi
 
 set -e
 
-curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
-
 echo "Updates packages. Asks for your password."
 sudo apt-get update -y
+
+echo "Installs Node 6"
+sudo apt-get install -y snapd
+sudo snap install node --classic --channel=6
 
 echo "Installs packages. Give your password when asked."
 sudo apt-get --ignore-missing install build-essential git-core curl openssl libssl-dev libcurl4-openssl-dev zlib1g zlib1g-dev libreadline6-dev libyaml-dev libsqlite3-dev libsqlite3-0 sqlite3 libxml2-dev libxslt1-dev libffi-dev software-properties-common libgdm-dev libncurses5-dev automake autoconf libtool bison postgresql postgresql-contrib libpq-dev pgadmin3 libc6-dev nodejs -y


### PR DESCRIPTION
Node 6 is not available via nodesource for Ubuntu 18.10 (cosmic).

However, it can be installed via snap, which has been built in to Ubuntu for a few years. 

This will install `snapd` if it's not already installed. Then it will install Node 6.

Takes care of #52 