### PR TITLE
Remove duplicated gemrc edit

### DIFF
--- a/rails-install-ubuntu.sh
+++ b/rails-install-ubuntu.sh
@@ -23,7 +23,6 @@ echo "Install ImageMagick for image processing"
 sudo apt-get install imagemagick --fix-missing -y
 
 echo "Install rbenv (Ruby version manager) for handling the Ruby installation"
-echo "gem: --no-ri --no-rdoc" > ~/.gemrc
 
 RBENV_INSTALL_PATH="$HOME/.rbenv"
 if [ -d "$RBENV_INSTALL_PATH" ]; then


### PR DESCRIPTION
There are two same lines for editing `gemrc`.
It's related to gem install, so it should be located to near `gem install`.